### PR TITLE
Add --devicename argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ $ pip install -r requirements.txt
 # Usage
 ```bash
 $ python print.py --help
-usage: print.py [-h] [--log-level {debug,info,warn,error}] [--img-binarization-algo {mean-threshold,floyd-steinberg}] [--show-preview] filename
+usage: print.py [-h] [--devicename] [--log-level {debug,info,warn,error}] [--img-binarization-algo {mean-threshold,floyd-steinberg}] [--show-preview] filename
 
 prints an image on your cat thermal printer
 
@@ -28,6 +28,7 @@ positional arguments:
 
 optional arguments:
   -h, --help            show this help message and exit
+  --devicename          Specify the Bluetooth device name to search for. Default value is GT01.
   --log-level {debug,info,warn,error}
   --img-binarization-algo {mean-threshold,floyd-steinberg}
                         Which image binarization algorithm to use.

--- a/catprinter/ble.py
+++ b/catprinter/ble.py
@@ -30,8 +30,8 @@ def chunkify(data, chunk_size):
     )
 
 
-async def run_ble(data, logger):
-    address = await scan('GT01', SCAN_TIMEOUT_S, logger)
+async def run_ble(data, devicename, logger):
+    address = await scan(devicename, SCAN_TIMEOUT_S, logger)
     logger.info(f'⏳ Connecting to {address}...')
     async with BleakClient(address) as client:
         logger.info(

--- a/print.py
+++ b/print.py
@@ -19,6 +19,8 @@ def parse_args():
                       help='Which image binarization algorithm to use.')
     args.add_argument('--show-preview', action='store_true',
                       help='If set, displays the final image and asks the user for confirmation before printing.')
+    args.add_argument('--devicename', type=str, default='GT01',
+                      help='Specify the Bluetooth device name to search for. Default value is GT01.')
     return args.parse_args()
 
 
@@ -48,7 +50,7 @@ def main():
     logger.info(f'✅ Generated BLE commands: {len(data)} bytes')
 
     loop = asyncio.get_event_loop()
-    loop.run_until_complete(run_ble(data, logger))
+    loop.run_until_complete(run_ble(data, args.devicename, logger))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This fixes #2 by introducing a `--devicename` argument. 

The default value is `GT01` so functionally the script behaviour doesn't change but now the user can specify their device name for example:

```
python printer.py --devicename GB02 cool.png
```