### PR TITLE
fix: install of macOS-only requirements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .DS_Store
+.idea/
+.vscode/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,10 +14,10 @@ prompt-toolkit==3.0.19
 ptyprocess==0.7.0
 pycodestyle==2.7.0
 Pygments==2.9.0
-pyobjc-core==7.3
-pyobjc-framework-Cocoa==7.3
-pyobjc-framework-CoreBluetooth==7.3
-pyobjc-framework-libdispatch==7.3
+pyobjc-core==7.3; sys_platform == 'darwin'
+pyobjc-framework-Cocoa==7.3; sys_platform == 'darwin'
+pyobjc-framework-CoreBluetooth==7.3; sys_platform == 'darwin'
+pyobjc-framework-libdispatch==7.3; sys_platform == 'darwin'
 toml==0.10.2
 traitlets==5.0.5
 wcwidth==0.2.5


### PR DESCRIPTION
Conditionals on requirements.txt to avoid installing these requirements (`pyobjc-*`) on non-macOS platforms

Closes #4 (proposal c). Only tested under Linux (requirements are skipped, app works fine).