### PR TITLE
feat: warn when the input file does not exist

### DIFF
--- a/print.py
+++ b/print.py
@@ -2,6 +2,7 @@ import argparse
 import asyncio
 import logging
 import sys
+import os
 
 from catprinter.cmds import PRINT_WIDTH, cmds_print_img
 from catprinter.ble import run_ble
@@ -38,6 +39,11 @@ def main():
 
     log_level = getattr(logging, args.log_level.upper())
     logger = make_logger(log_level)
+
+    filename = args.filename
+    if not os.path.exists(filename):
+        logger.info('🛑 File not found. Exiting.')
+        return
 
     bin_img = read_img(args.filename, PRINT_WIDTH,
                        logger, args.img_binarization_algo, args.show_preview)


### PR DESCRIPTION
I though it may be interesting to warn on the CLI when the user inputs a file that does not exist. Otherwise, the application would fail with something less friendly:

```bash
(catprinter) david@Ubuntu-Main:~/Python/catprinter$ python print.py /media/ram/foo.png
Traceback (most recent call last):
  File "print.py", line 57, in <module>
    main()
  File "print.py", line 42, in main
    bin_img = read_img(args.filename, PRINT_WIDTH,
  File "/home/david/Python/catprinter/catprinter/img.py", line 35, in read_img
    height = im.shape[0]
AttributeError: 'NoneType' object has no attribute 'shape'
(catprinter) david@Ubuntu-Main:~/Python/catprinter$
```

Now it would return the following:

```bash
(catprinter) david@Ubuntu-Main:~/Python/catprinter$ python print.py /media/foo/bar.png
🛑 File not found. Exiting.
(catprinter) david@Ubuntu-Main:~/Python/catprinter$
```