### PR TITLE
Added dark mode for advanced print quality

### DIFF
--- a/catprinter/cmds.py
+++ b/catprinter/cmds.py
@@ -152,13 +152,16 @@ def cmd_print_row(img_row):
     return b_arr
 
 
-def cmds_print_img(img):
+def cmds_print_img(img, dark_mode=False):
+
+    PRINTER_MODE = CMD_PRINT_TEXT if dark_mode else CMD_PRINT_IMG
+
     data = \
         CMD_GET_DEV_STATE + \
         CMD_SET_QUALITY_200_DPI + \
         CMD_LATTICE_START + \
         cmd_set_energy(12000) + \
-        CMD_PRINT_IMG + \
+        PRINTER_MODE + \
         cmd_feed_paper(30)
     for row in img:
         data += cmd_print_row(row)

--- a/print.py
+++ b/print.py
@@ -23,6 +23,8 @@ def parse_args():
                       help='If set, displays the final image and asks the user for confirmation before printing.')
     args.add_argument('--devicename', type=str, default='GT01',
                       help='Specify the Bluetooth device name to search for. Default value is GT01.')
+    args.add_argument('--darker', action='store_true',
+                      help="Print the image in text mode. This leads to more contrast, but slower speed")
     return args.parse_args()
 
 
@@ -53,7 +55,7 @@ def main():
         return
 
     logger.info(f'✅ Read image: {bin_img.shape} (h, w) pixels')
-    data = cmds_print_img(bin_img)
+    data = cmds_print_img(bin_img, dark_mode=args.darker)
     logger.info(f'✅ Generated BLE commands: {len(data)} bytes')
 
     loop = asyncio.get_event_loop()


### PR DESCRIPTION
the printer can now print in 'text mode' if the `--darker` flag is set. This makes the print a bit slower, but the contrasts are much higher. Here is an example:
![IMG_20211231_165801__01](https://user-images.githubusercontent.com/2639206/147831597-6aac2406-32be-48d2-97a8-447f933bad27.jpg)

