### PR TITLE
Implements auto-discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,20 +19,26 @@ $ pip install -r requirements.txt
 # Usage
 ```bash
 $ python print.py --help
-usage: print.py [-h] [--devicename] [--log-level {debug,info,warn,error}] [--img-binarization-algo {mean-threshold,floyd-steinberg}] [--show-preview] filename
+usage: print.py [-h] [--log-level {debug,info,warn,error}] [--img-binarization-algo {mean-threshold,floyd-steinberg,halftone}]
+                [--show-preview] [--devicename DEVICENAME] [--darker]
+                filename
 
 prints an image on your cat thermal printer
 
 positional arguments:
   filename
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
-  --devicename          Specify the Bluetooth device name to search for. Default value is GT01.
   --log-level {debug,info,warn,error}
-  --img-binarization-algo {mean-threshold,floyd-steinberg, halftone}
+  --img-binarization-algo {mean-threshold,floyd-steinberg,halftone}
                         Which image binarization algorithm to use.
   --show-preview        If set, displays the final image and asks the user for confirmation before printing.
+  --devicename DEVICENAME
+                        Specify the Bluetooth Low Energy (BLE) device name to search for. If not specified, the script will try to
+                        auto discover the printer based on its advertised BLE service UUIDs. Common names are similar to "GT01",
+                        "GB02", "GB03".
+  --darker              Print the image in text mode. This leads to more contrast, but slower speed.
 ```
 
 # Example

--- a/print.py
+++ b/print.py
@@ -21,15 +21,17 @@ def parse_args():
                       default='floyd-steinberg',
                       help='Which image binarization algorithm to use.')
     args.add_argument('--show-preview', action='store_true',
-                      help='If set, displays the final image and asks the user \
-                          for confirmation before printing.')
+                      help='If set, displays the final image and asks the user for \
+                          confirmation before printing.')
     args.add_argument('--devicename', type=str, default='',
-                      help='Specify the Bluetooth device name to search for. If \
-                          not specified, the script will try to auto discover the \
-                          printer based on its advertised BLE service UUIDs.')
+                      help='Specify the Bluetooth Low Energy (BLE) device name to    \
+                          search for. If not specified, the script will try to       \
+                          auto discover the printer based on its advertised BLE      \
+                          service UUIDs. Common names are similar to "GT01", "GB02", \
+                          "GB03".')
     args.add_argument('--darker', action='store_true',
                       help="Print the image in text mode. This leads to more contrast, \
-                          but slower speed")
+                          but slower speed.")
     return args.parse_args()
 
 

--- a/print.py
+++ b/print.py
@@ -21,11 +21,15 @@ def parse_args():
                       default='floyd-steinberg',
                       help='Which image binarization algorithm to use.')
     args.add_argument('--show-preview', action='store_true',
-                      help='If set, displays the final image and asks the user for confirmation before printing.')
-    args.add_argument('--devicename', type=str, default='GT01',
-                      help='Specify the Bluetooth device name to search for. Default value is GT01.')
+                      help='If set, displays the final image and asks the user \
+                          for confirmation before printing.')
+    args.add_argument('--devicename', type=str, default='',
+                      help='Specify the Bluetooth device name to search for. If \
+                          not specified, the script will try to auto discover the \
+                          printer based on its advertised BLE service UUIDs.')
     args.add_argument('--darker', action='store_true',
-                      help="Print the image in text mode. This leads to more contrast, but slower speed")
+                      help="Print the image in text mode. This leads to more contrast, \
+                          but slower speed")
     return args.parse_args()
 
 
@@ -59,7 +63,9 @@ def main():
     data = cmds_print_img(bin_img, dark_mode=args.darker)
     logger.info(f'✅ Generated BLE commands: {len(data)} bytes')
 
-    asyncio.run(run_ble(data, args.devicename, logger))
+    # Try to autodiscover a printer if --devicename is not specified.
+    autodiscover = not args.devicename
+    asyncio.run(run_ble(data, args.devicename, autodiscover, logger))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
If `--devicename` is not specified, the script will try to auto-discovery
printers based on their advertised BLE service UUIDs.