### PR TITLE
Feature none binarization

### DIFF
--- a/catprinter/img.py
+++ b/catprinter/img.py
@@ -117,6 +117,15 @@ def read_img(
         resized = resized > 127
     elif img_binarization_algo == 'mean-threshold':
         resized = resized > resized.mean()
+    elif img_binarization_algo == 'none':
+        if width == print_width:
+            resized = im > 127
+        else:
+            logger.error(
+            f'🛑 Wrong width of {img_binarization_algo} px. {print_width} required')
+            raise RuntimeError(
+            f'Wrong width of {img_binarization_algo} px. {print_width} required')
+
     else:
         logger.error(
             f'🛑 Unknown image binarization algorithm: {img_binarization_algo}')

--- a/catprinter/img.py
+++ b/catprinter/img.py
@@ -122,9 +122,9 @@ def read_img(
             resized = im > 127
         else:
             logger.error(
-            f'🛑 Wrong width of {width} px. {print_width} required')
+            f'🛑 Wrong width of {width} px. An image with a width of {print_width} px is required for "none" binarization')
             raise RuntimeError(
-            f'Wrong width of {width} px. {print_width} required')
+            f'Wrong width of {width} px. An image with a width of {print_width} px is required for "none" binarization')
 
     else:
         logger.error(

--- a/catprinter/img.py
+++ b/catprinter/img.py
@@ -122,9 +122,9 @@ def read_img(
             resized = im > 127
         else:
             logger.error(
-            f'🛑 Wrong width of {img_binarization_algo} px. {print_width} required')
+            f'🛑 Wrong width of {width} px. {print_width} required')
             raise RuntimeError(
-            f'Wrong width of {img_binarization_algo} px. {print_width} required')
+            f'Wrong width of {width} px. {print_width} required')
 
     else:
         logger.error(

--- a/print.py
+++ b/print.py
@@ -19,7 +19,7 @@ def parse_args():
                       choices=['mean-threshold',
                                'floyd-steinberg', 'halftone', 'none'],
                       default='floyd-steinberg',
-                      help='Which image binarization algorithm to use.')
+                      help=f'Which image binarization algorithm to use. If \'none\' is used, no binarization will be used. In this case the image has to have a width of {PRINT_WIDTH} px.')
     args.add_argument('--show-preview', action='store_true',
                       help='If set, displays the final image and asks the user for \
                           confirmation before printing.')

--- a/print.py
+++ b/print.py
@@ -17,7 +17,7 @@ def parse_args():
                       choices=['debug', 'info', 'warn', 'error'], default='info')
     args.add_argument('--img-binarization-algo', type=str,
                       choices=['mean-threshold',
-                               'floyd-steinberg', 'halftone'],
+                               'floyd-steinberg', 'halftone', 'none'],
                       default='floyd-steinberg',
                       help='Which image binarization algorithm to use.')
     args.add_argument('--show-preview', action='store_true',


### PR DESCRIPTION
Hello,
I propose to add an option to disable the binarization which could be helpful in some cases.

The added code assumes that the image uses a correct width of PRINT_WIDTH = 384.

If you have any remarks on this pull request I am happy to incorporate them. 