### PR TITLE
add short options, allow abbreviating binarization_algo

### DIFF
--- a/catprinter/img.py
+++ b/catprinter/img.py
@@ -105,19 +105,19 @@ def read_img(
         ),
         interpolation=cv2.INTER_AREA)
 
-    if img_binarization_algo.startswith('f'):
+    if img_binarization_algo == 'floyd-steinberg':
         logger.info('⏳ Applying Floyd-Steinberg dithering to image...')
         resized = floyd_steinberg_dither(resized)
         logger.info('✅ Done.')
         resized = resized > 127
-    elif img_binarization_algo.startswith('h'):
+    elif img_binarization_algo == 'halftone':
         logger.info('⏳ Applying halftone dithering to image...')
         resized = halftone_dither(resized)
         logger.info('✅ Done.')
         resized = resized > 127
-    elif img_binarization_algo.startswith('m'):
+    elif img_binarization_algo == 'mean-threshold':
         resized = resized > resized.mean()
-    elif img_binarization_algo.startswith('n'):
+    elif img_binarization_algo == 'none':
         if width == print_width:
             resized = im > 127
         else:

--- a/catprinter/img.py
+++ b/catprinter/img.py
@@ -105,19 +105,19 @@ def read_img(
         ),
         interpolation=cv2.INTER_AREA)
 
-    if img_binarization_algo == 'floyd-steinberg':
+    if img_binarization_algo.startswith('f'):
         logger.info('⏳ Applying Floyd-Steinberg dithering to image...')
         resized = floyd_steinberg_dither(resized)
         logger.info('✅ Done.')
         resized = resized > 127
-    elif img_binarization_algo == 'halftone':
+    elif img_binarization_algo.startswith('h'):
         logger.info('⏳ Applying halftone dithering to image...')
         resized = halftone_dither(resized)
         logger.info('✅ Done.')
         resized = resized > 127
-    elif img_binarization_algo == 'mean-threshold':
+    elif img_binarization_algo.startswith('m'):
         resized = resized > resized.mean()
-    elif img_binarization_algo == 'none':
+    elif img_binarization_algo.startswith('n'):
         if width == print_width:
             resized = im > 127
         else:

--- a/print.py
+++ b/print.py
@@ -8,13 +8,6 @@ from catprinter.cmds import PRINT_WIDTH, cmds_print_img
 from catprinter.ble import run_ble
 from catprinter.img import read_img
 
-class prefixchoice(list):
-    def __contains__(self, other):
-        for i in self:
-            if i.startswith(other):
-                return True
-        return False
-
 def parse_args():
     args = argparse.ArgumentParser(
         description='prints an image on your cat thermal printer')
@@ -22,10 +15,12 @@ def parse_args():
     args.add_argument('-l', '--log-level', type=str,
                       choices=['debug', 'info', 'warn', 'error'], default='info')
     args.add_argument('-b', '--img-binarization-algo', type=str,
-                      choices=prefixchoice(['mean-threshold',
-                               'floyd-steinberg', 'halftone', 'none']),
+                      choices=['mean-threshold',
+                               'floyd-steinberg', 'halftone', 'none'],
                       default='floyd-steinberg',
-                      help=f'Which image binarization algorithm to use. If \'none\' is used, no binarization will be used. In this case the image has to have a width of {PRINT_WIDTH} px.')
+                      help=f'Which image binarization algorithm to use. If \'none\'  \
+                             is used, no binarization will be used. In this case the \
+                             image has to have a width of {PRINT_WIDTH} px.')
     args.add_argument('-s', '--show-preview', action='store_true',
                       help='If set, displays the final image and asks the user for \
                           confirmation before printing.')

--- a/print.py
+++ b/print.py
@@ -8,28 +8,34 @@ from catprinter.cmds import PRINT_WIDTH, cmds_print_img
 from catprinter.ble import run_ble
 from catprinter.img import read_img
 
+class prefixchoice(list):
+    def __contains__(self, other):
+        for i in self:
+            if i.startswith(other):
+                return True
+        return False
 
 def parse_args():
     args = argparse.ArgumentParser(
         description='prints an image on your cat thermal printer')
     args.add_argument('filename', type=str)
-    args.add_argument('--log-level', type=str,
+    args.add_argument('-l', '--log-level', type=str,
                       choices=['debug', 'info', 'warn', 'error'], default='info')
-    args.add_argument('--img-binarization-algo', type=str,
-                      choices=['mean-threshold',
-                               'floyd-steinberg', 'halftone', 'none'],
+    args.add_argument('-b', '--img-binarization-algo', type=str,
+                      choices=prefixchoice(['mean-threshold',
+                               'floyd-steinberg', 'halftone', 'none']),
                       default='floyd-steinberg',
                       help=f'Which image binarization algorithm to use. If \'none\' is used, no binarization will be used. In this case the image has to have a width of {PRINT_WIDTH} px.')
-    args.add_argument('--show-preview', action='store_true',
+    args.add_argument('-s', '--show-preview', action='store_true',
                       help='If set, displays the final image and asks the user for \
                           confirmation before printing.')
-    args.add_argument('--devicename', type=str, default='',
+    args.add_argument('-d', '--devicename', type=str, default='',
                       help='Specify the Bluetooth Low Energy (BLE) device name to    \
                           search for. If not specified, the script will try to       \
                           auto discover the printer based on its advertised BLE      \
                           service UUIDs. Common names are similar to "GT01", "GB02", \
                           "GB03".')
-    args.add_argument('--darker', action='store_true',
+    args.add_argument('-t', '--darker', action='store_true',
                       help="Print the image in text mode. This leads to more contrast, \
                           but slower speed.")
     return args.parse_args()


### PR DESCRIPTION
I hate typing, and `./print.py -b h -s cat.jpg` feels soo much better than the long version.

This assumes that binarization algos will always starting with a unique letter.