### PR TITLE
Allow connecting by address

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,9 @@ $ pip install -r requirements.txt
 # Usage
 ```bash
 $ ./print.py --help
-usage: print.py [-h] [--log-level {debug,info,warn,error}] [--img-binarization-algo {mean-threshold,floyd-steinberg,halftone}]
-                [--show-preview] [--devicename DEVICENAME] [--darker]
+usage: print.py [-h] [-l {debug,info,warn,error}]
+                [-b {mean-threshold,floyd-steinberg,halftone,none}] [-s]
+                [-d DEVICE] [-t]
                 filename
 
 prints an image on your cat thermal printer
@@ -28,17 +29,23 @@ prints an image on your cat thermal printer
 positional arguments:
   filename
 
-options:
+optional arguments:
   -h, --help            show this help message and exit
-  --log-level {debug,info,warn,error}
-  --img-binarization-algo {mean-threshold,floyd-steinberg,halftone}
-                        Which image binarization algorithm to use.
-  --show-preview        If set, displays the final image and asks the user for confirmation before printing.
-  --devicename DEVICENAME
-                        Specify the Bluetooth Low Energy (BLE) device name to search for. If not specified, the script will try to
-                        auto discover the printer based on its advertised BLE service UUIDs. Common names are similar to "GT01",
-                        "GB02", "GB03".
-  --darker              Print the image in text mode. This leads to more contrast, but slower speed.
+  -l {debug,info,warn,error}, --log-level {debug,info,warn,error}
+  -b {mean-threshold,floyd-steinberg,halftone,none}, --img-binarization-algo {mean-threshold,floyd-steinberg,halftone,none}
+                        Which image binarization algorithm to use. If 'none'
+                        is used, no binarization will be used. In this case
+                        the image has to have a width of 384 px.
+  -s, --show-preview    If set, displays the final image and asks the user for
+                        confirmation before printing.
+  -d DEVICE, --device DEVICE
+                        The printer's Bluetooth Low Energy (BLE) address (MAC
+                        address on Linux; UUID on macOS) or advertisement name
+                        (e.g.: "GT01", "GB02", "GB03"). If omitted, the the
+                        script will try to auto discover the printer based on
+                        its advertised BLE services.
+  -t, --darker          Print the image in text mode. This leads to more
+                        contrast, but slower speed.
 ```
 
 # Example

--- a/catprinter/ble.py
+++ b/catprinter/ble.py
@@ -1,4 +1,6 @@
 import asyncio
+import contextlib
+import uuid
 from typing import Optional
 
 from bleak import BleakClient, BleakScanner
@@ -54,9 +56,20 @@ def chunkify(data, chunk_size):
     )
 
 
-async def run_ble(data, devicename: Optional[str]):
+async def get_device_address(device: Optional[str]):
+    # See if we were passed a string that smells like an UUID or MAC address.
+    if device:
+        with contextlib.suppress(ValueError):
+            return str(uuid.UUID(device))
+        if device.count(':') == 5 and device.replace(':', '').isalnum():
+            return device
+
+    return await scan(device, timeout=SCAN_TIMEOUT_S)
+
+
+async def run_ble(data, device: Optional[str]):
     try:
-        address = await scan(devicename, timeout=SCAN_TIMEOUT_S)
+        address = await get_device_address(device)
     except RuntimeError as e:
         logger.error(f'🛑 {e}')
         return

--- a/catprinter/ble.py
+++ b/catprinter/ble.py
@@ -1,4 +1,6 @@
 import asyncio
+from typing import Optional
+
 from bleak import BleakClient, BleakScanner
 from bleak.backends.scanner import AdvertisementData
 from bleak.backends.device import BLEDevice
@@ -23,7 +25,8 @@ SCAN_TIMEOUT_S = 10
 WAIT_AFTER_DATA_SENT_S = 30
 
 
-async def scan(name, timeout, autodiscover):
+async def scan(name: Optional[str], timeout: int):
+    autodiscover = (not name)
     if autodiscover:
         logger.info('⏳ Trying to auto-discover a printer...')
     else:
@@ -51,9 +54,9 @@ def chunkify(data, chunk_size):
     )
 
 
-async def run_ble(data, devicename, autodiscover):
+async def run_ble(data, devicename: Optional[str]):
     try:
-        address = await scan(devicename, SCAN_TIMEOUT_S, autodiscover)
+        address = await scan(devicename, timeout=SCAN_TIMEOUT_S)
     except RuntimeError as e:
         logger.error(f'🛑 {e}')
         return

--- a/print.py
+++ b/print.py
@@ -73,8 +73,7 @@ def main():
     logger.info(f'✅ Generated BLE commands: {len(data)} bytes')
 
     # Try to autodiscover a printer if --devicename is not specified.
-    autodiscover = not args.devicename
-    asyncio.run(run_ble(data, args.devicename, autodiscover))
+    asyncio.run(run_ble(data, devicename=args.devicename))
 
 
 if __name__ == '__main__':

--- a/print.py
+++ b/print.py
@@ -10,6 +10,7 @@ from catprinter.cmds import PRINT_WIDTH, cmds_print_img
 from catprinter.ble import run_ble
 from catprinter.img import read_img, show_preview
 
+
 def parse_args():
     args = argparse.ArgumentParser(
         description='prints an image on your cat thermal printer')
@@ -26,12 +27,14 @@ def parse_args():
     args.add_argument('-s', '--show-preview', action='store_true',
                       help='If set, displays the final image and asks the user for \
                           confirmation before printing.')
-    args.add_argument('-d', '--devicename', type=str, default='',
-                      help='Specify the Bluetooth Low Energy (BLE) device name to    \
-                          search for. If not specified, the script will try to       \
-                          auto discover the printer based on its advertised BLE      \
-                          service UUIDs. Common names are similar to "GT01", "GB02", \
-                          "GB03".')
+    args.add_argument('-d', '--device', type=str, default='',
+                      help=(
+                          'The printer\'s Bluetooth Low Energy (BLE) address '
+                          '(MAC address on Linux; UUID on macOS) '
+                          'or advertisement name (e.g.: "GT01", "GB02", "GB03"). '
+                          'If omitted, the the script will try to auto discover '
+                          'the printer based on its advertised BLE services.'
+                      ))
     args.add_argument('-t', '--darker', action='store_true',
                       help="Print the image in text mode. This leads to more contrast, \
                           but slower speed.")
@@ -72,8 +75,8 @@ def main():
     data = cmds_print_img(bin_img, dark_mode=args.darker)
     logger.info(f'✅ Generated BLE commands: {len(data)} bytes')
 
-    # Try to autodiscover a printer if --devicename is not specified.
-    asyncio.run(run_ble(data, devicename=args.devicename))
+    # Try to autodiscover a printer if --device is not specified.
+    asyncio.run(run_ble(data, device=args.device))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR allows one to pass in the BLE address of the printer instead, to avoid having to wait for autodiscovery.