### PR TITLE
Fix: up/downscaling rounding errors cause out-of-bounds index accessing.

### DIFF
--- a/catprinter/img.py
+++ b/catprinter/img.py
@@ -101,8 +101,8 @@ def read_img(
     resized = cv2.resize(
         im,
         (
-            int(width * factor),
-            int(height * factor)
+            ceil(width * factor),
+            ceil(height * factor)
         ),
         interpolation=cv2.INTER_AREA)
 

--- a/catprinter/img.py
+++ b/catprinter/img.py
@@ -101,8 +101,8 @@ def read_img(
     resized = cv2.resize(
         im,
         (
-            ceil(width * factor),
-            ceil(height * factor)
+            print_width,
+            int(height * factor)
         ),
         interpolation=cv2.INTER_AREA)
 


### PR DESCRIPTION
For some input image widths, the scaling can lead to images with widths of 383 pixels instead of the intended 384. In the case of upscaling, this can happen for widths of, for example, 47 and 94. In the case of downscaling, this can happen for widths of, for example, 535 and 559.

Below are 2 test images used (with the given widths):

![upscale](https://user-images.githubusercontent.com/39132384/170263153-b743cc7c-753a-4d8d-8ced-780e30d2296c.png)

![downscale](https://user-images.githubusercontent.com/39132384/170263172-999c9097-a75e-48c6-ad8e-f560873bdfc0.png)
