### PR TITLE
Add support for darker prints

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,7 @@ $ pip install -r requirements.txt
 # Usage
 ```bash
 $ ./print.py --help
-usage: print.py [-h] [-l {debug,info,warn,error}]
-                [-b {mean-threshold,floyd-steinberg,halftone,none}] [-s]
-                [-d DEVICE] [-t]
+usage: print.py [-h] [-l {debug,info,warn,error}] [-b {mean-threshold,floyd-steinberg,atkinson,halftone,none}] [-s] [-d DEVICE] [-e ENERGY]
                 filename
 
 prints an image on your cat thermal printer
@@ -33,19 +31,15 @@ options:
   -h, --help            show this help message and exit
   -l {debug,info,warn,error}, --log-level {debug,info,warn,error}
   -b {mean-threshold,floyd-steinberg,atkinson,halftone,none}, --img-binarization-algo {mean-threshold,floyd-steinberg,atkinson,halftone,none}
-                        Which image binarization algorithm to use. If 'none'
-                        is used, no binarization will be used. In this case
-                        the image has to have a width of 384 px.
-  -s, --show-preview    If set, displays the final image and asks the user for
-                        confirmation before printing.
+                        Which image binarization algorithm to use. If 'none' is used, no binarization will be used. In this case the image has to
+                        have a width of 384 px.
+  -s, --show-preview    If set, displays the final image and asks the user for confirmation before printing.
   -d DEVICE, --device DEVICE
-                        The printer's Bluetooth Low Energy (BLE) address (MAC
-                        address on Linux; UUID on macOS) or advertisement name
-                        (e.g.: "GT01", "GB02", "GB03"). If omitted, the the
-                        script will try to auto discover the printer based on
-                        its advertised BLE services.
-  -t, --darker          Print the image in text mode. This leads to more
-                        contrast, but slower speed.
+                        The printer's Bluetooth Low Energy (BLE) address (MAC address on Linux; UUID on macOS) or advertisement name (e.g.:
+                        "GT01", "GB02", "GB03"). If omitted, the the script will try to auto discover the printer based on its advertised BLE
+                        services.
+  -e ENERGY, --energy ENERGY
+                        Thermal energy. Between 0x0000 (light) and 0xffff (darker, default).
 ```
 
 # Example

--- a/catprinter/cmds.py
+++ b/catprinter/cmds.py
@@ -94,7 +94,25 @@ def cmd_set_energy(val):
         0,
         0xff,
     ])
-    b_arr[7] = chk_sum(b_arr, 6, 2)
+    b_arr[8] = chk_sum(b_arr, 6, 2)
+    return bs(b_arr)
+
+
+def cmd_apply_energy():
+    b_arr = bs(
+        [
+            81,
+            120,
+            -66,
+            0,
+            1,
+            0,
+            1,
+            0,
+            0xff,
+        ]
+    )
+    b_arr[7] = chk_sum(b_arr, 6, 1)
     return bs(b_arr)
 
 
@@ -167,13 +185,12 @@ def cmd_print_row(img_row):
     return b_arr
 
 
-def cmds_print_img(img, dark_mode=False):
-
-    PRINTER_MODE = CMD_PRINT_TEXT if dark_mode else CMD_PRINT_IMG
-
+def cmds_print_img(img, energy: int = 0xffff):
     data = \
         CMD_GET_DEV_STATE + \
         CMD_SET_QUALITY_200_DPI + \
+        cmd_set_energy(energy) + \
+        cmd_apply_energy() + \
         CMD_LATTICE_START
     for row in img:
         data += cmd_print_row(row)

--- a/print.py
+++ b/print.py
@@ -36,7 +36,7 @@ def parse_args():
                           'the printer based on its advertised BLE services.'
                       ))
     args.add_argument('-e', '--energy', type=lambda h: int(h.removeprefix("0x"), 16),
-                      help="Thermal energy. Between 0x0000 (light) and 0xffff (darker)",
+                      help="Thermal energy. Between 0x0000 (light) and 0xffff (darker, default).",
                       default="0xffff")
     return args.parse_args()
 

--- a/print.py
+++ b/print.py
@@ -35,9 +35,9 @@ def parse_args():
                           'If omitted, the the script will try to auto discover '
                           'the printer based on its advertised BLE services.'
                       ))
-    args.add_argument('-t', '--darker', action='store_true',
-                      help="Print the image in text mode. This leads to more contrast, \
-                          but slower speed.")
+    args.add_argument('-e', '--energy', type=lambda h: int(h.removeprefix("0x"), 16),
+                      help="Thermal energy. Between 0x0000 (light) and 0xffff (darker)",
+                      default="0xffff")
     return args.parse_args()
 
 
@@ -72,7 +72,7 @@ def main():
         return
 
     logger.info(f'✅ Read image: {bin_img.shape} (h, w) pixels')
-    data = cmds_print_img(bin_img, dark_mode=args.darker)
+    data = cmds_print_img(bin_img, energy=args.energy)
     logger.info(f'✅ Generated BLE commands: {len(data)} bytes')
 
     # Try to autodiscover a printer if --device is not specified.


### PR DESCRIPTION
This adds the -e/--energy switch, which lets us specify the thermal energy to the printer. It's a value between 0x0000 (light) and 0xffff (darker).

Fixes #72 

![catprinter](https://github.com/user-attachments/assets/b10f4bb7-2140-43d5-aceb-f530caf5b773)
