### PR TITLE
fix: macOS compatibility - handle missing BlueZ import

### DIFF
--- a/catprinter/ble.py
+++ b/catprinter/ble.py
@@ -6,7 +6,11 @@ from typing import Optional
 from bleak import BleakClient, BleakScanner
 from bleak.backends.scanner import AdvertisementData
 from bleak.backends.device import BLEDevice
-from bleak.backends.bluezdbus.client import BleakClientBlueZDBus
+# In MacOS capture exception trying Linux library import and set a flag
+try:
+    from bleak.backends.bluezdbus.client import BleakClientBlueZDBus
+except ImportError:
+    BleakClientBlueZDBus = None
 from catprinter import logger
 
 # For some reason, bleak reports the 0xaf30 service on my macOS, while it reports
@@ -99,7 +103,8 @@ async def run_ble(data, device: Optional[str]):
     async with BleakClient(address) as client:
         # XXX: BlueZ incorrectly reports a fixed MTU of 23; force MTU negotiation manually.
         # https://bleak.readthedocs.io/en/latest/api/client.html#bleak.BleakClient.mtu_size
-        if isinstance(client, BleakClientBlueZDBus):
+        # Only use this library on Linux, not MacOS
+        if BleakClientBlueZDBus and isinstance(client, BleakClientBlueZDBus):
             await client._acquire_mtu()
 
         logger.info(f"✅ Connected: {client.is_connected}; MTU: {client.mtu_size}")


### PR DESCRIPTION
## Problem

On macOS, `BleakClientBlueZDBus` from `bleak.backends.bluezdbus.client` is not available — BlueZ is Linux-only. This caused an `ImportError` when running catprinter on macOS.

## Solution

- Wrap the `BleakClientBlueZDBus` import in a `try/except ImportError` block, setting it to `None` when unavailable.
- Guard the `isinstance` check with `BleakClientBlueZDBus and ...` so the manual MTU negotiation only runs on Linux (where BlueZ is present).

This makes the code fully compatible with both Linux and macOS with no behavior change on Linux.

## Testing

Tested successfully on macOS with a GB01/GB02 cat printer.